### PR TITLE
Better Unicode support for Url Generator and resource export/import

### DIFF
--- a/MrCMS.Web/Areas/Admin/Services/StringResourceUpdateService.cs
+++ b/MrCMS.Web/Areas/Admin/Services/StringResourceUpdateService.cs
@@ -50,7 +50,7 @@ namespace MrCMS.Web.Areas.Admin.Services
             }
             string result = string.Join(Environment.NewLine, data.Select(list => string.Join(",", list)));
 
-            return new FileContentResult(Encoding.Default.GetBytes(result), "text/csv")
+            return new FileContentResult(Encoding.UTF8.GetBytes(result), "text/csv")
             {
                 FileDownloadName =
                     "MrCMS-ResourceData-" + CurrentRequestData.Now +
@@ -62,7 +62,7 @@ namespace MrCMS.Web.Areas.Admin.Services
         {
             Stream inputStream = file.InputStream;
             inputStream.Position = 0;
-            var reader = new StreamReader(inputStream, Encoding.Default);
+            var reader = new StreamReader(inputStream, Encoding.UTF8);
             string data = reader.ReadToEnd();
             string[] rows = data.Split(new[] { "\r", "\n" }, StringSplitOptions.RemoveEmptyEntries);
             var resourceData = new List<StringResourceData>();

--- a/MrCMS/Helpers/SeoHelper.cs
+++ b/MrCMS/Helpers/SeoHelper.cs
@@ -23,6 +23,11 @@ namespace MrCMS.Helpers
 
         private static string RemoveDiacritics(string url)
         {
+            // Convert diacritical marks to normalized url characters
+            Regex regex = new Regex("\\p{IsCombiningDiacriticalMarks}+");
+            string temp = url.Normalize(NormalizationForm.FormD);
+            url = regex.Replace(temp, String.Empty).Replace('\u0111', 'd').Replace('\u0110', 'D');
+
             byte[] tempBytes = System.Text.Encoding.GetEncoding("ISO-8859-8").GetBytes(url);
             return System.Text.Encoding.UTF8.GetString(tempBytes);
         }


### PR DESCRIPTION
- Modify RemoveDiacritics function to convert diacritical marks to normalized characters instead of replace them with "-". This helps generate better SEO friendly url for many languages that have diacritical marks like Vietnamese.
-  Change stream encoding to UTF8 so that string resource import/export functions can work with Unicode characters