### PR TITLE
Fix database installation using mysql with raw connection string.

### DIFF
--- a/MrCMS/DbConfiguration/MySqlDatabaseCreator.cs
+++ b/MrCMS/DbConfiguration/MySqlDatabaseCreator.cs
@@ -27,6 +27,8 @@ namespace MrCMS.DbConfiguration
 
         public string GetConnectionString(InstallModel model)
         {
+            if (model.SqlConnectionInfo == SqlConnectionInfo.Raw) return model.DatabaseConnectionString;
+
             var builder = new MySqlConnectionStringBuilder
             {
                 IntegratedSecurity = model.SqlAuthenticationType == SqlAuthenticationType.Windows,


### PR DESCRIPTION
Hi Guys,

  It seems like the "Enter raw connection string (advanced)" is not working properly for MySql.  This cause exception when creating database for MySql.